### PR TITLE
Option to add modules under different directory

### DIFF
--- a/foopak
+++ b/foopak
@@ -41,6 +41,12 @@ OPTIONS:
 	--tag,-t,	use specific tag or commit
 	--commit,-c	default is the latest commit in the default remote
 
+	--dir,-d	add module under different directory
+			default is foopak_modules
+			WARNING:
+				modules outside 'foopak_modules'
+				will not be scanned for commands
+
 	--branch,-b	use specific branch
 			default is the default remote branch
 
@@ -103,6 +109,7 @@ fpf_remove() {
 fpf_add() {
 	###   DEFAULTS    ###
 	git_server="https://github.com"
+	modules_relative_dir="foopak_modules"
 	module_options=()
 	###   DEFAULTS   ###
 
@@ -121,6 +128,10 @@ fpf_add() {
 
 			--commit|-c|--tag|-t)
 				module_version=$2; shift 2
+			;;
+
+			--dir|-d)
+				modules_relative_dir=$2; shift 2
 			;;
 
 			--help|-h)
@@ -155,12 +166,14 @@ fpf_add() {
 	fi
 	###   READ POSITIONAL ARGS    ###
 
+	modules_dir="$fpv_modules_dir/$modules_relative_dir"
+
 	module_parent_dir=$(dirname "$module_alias")
 	if [ "${module_parent_dir:0:1}" != "." ]; then
-		mkdir -p "$fpv_modules_dir/$module_parent_dir"
+		mkdir -p "$modules_dir/$module_parent_dir"
 	fi
 
-	module_install_path="$fpv_relative_modules_dir/$module_alias"
+	module_install_path="$modules_relative_dir/$module_alias"
 
 	if [ -e "$module_install_path" ]; then
 		echo "ERROR: could not add module: directory '$module_install_path' already exists" >&2

--- a/foopak
+++ b/foopak
@@ -57,6 +57,7 @@ EOF
 
 fpf_remove() {
 	###    DEFAULTS    ###
+	modules_relative_dir="foopak_modules"
 	###    DEFAULTS    ###
 
 	###    READ NAMED ARGS    ###
@@ -64,6 +65,10 @@ fpf_remove() {
 	while [ "$reading_named_args" == "true" ]; do
 		option=$1
 		case "$option" in
+			--dir|-d)
+				modules_relative_dir=$2; shift 2
+			;;
+
 			--help|-h)
 				fpp_print_remove_help
 				exit 0
@@ -93,7 +98,9 @@ fpf_remove() {
 	fi
 	###    READ POSITIONAL ARGS    ###
 
-	module_install_path="$fpv_modules_dir/$module_alias"
+	modules_dir="$fpv_project_root/$modules_relative_dir"
+
+	module_install_path="$modules_dir/$module_alias"
 
 	if [ ! -d "$module_install_path" ]; then
 		echo "ERROR: module '$module_alias' not installed" >&2

--- a/tests/add-modules/test_with-specific-directory.sh
+++ b/tests/add-modules/test_with-specific-directory.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+
+project_root=$(realpath "$(dirname $0)/../..")
+
+oneTimeSetUp() {
+	environment_dir=$("$project_root/tests/setup_environment.sh")
+	cd $environment_dir
+	output=$(./foopak add --dir "test_modules/subdir" rockerbacon/foopak-mock-module 2>&1); \
+		exit_code=$?
+
+	gitmodules_content=$(cat .gitmodules)
+}
+
+oneTimeTearDown() {
+	cd "$project_root"
+	rm -rf $environment_dir
+}
+
+test_should_execute_without_errors() {
+	assertEquals "program exited with error:\n$output\n\n" "0" "$exit_code"
+}
+
+test_should_add_module_in_correct_path() {
+	assertTrue \
+		"path 'test_modules/subdir/rockerbacon/foopak-mock-module' not found" \
+		'[ -d "test_modules/subdir/rockerbacon/foopak-mock-module" ]'
+}
+
+test_should_not_be_able_to_execute_scripts_in_module_root() {
+	expected_output="unknown command 'cmd-1'"
+	actual_output=$(./foopak cmd-1 2>&1); exit_status=$?
+	assertNotEquals "program exited with success code." "0" "$exit_status"
+	assertContains "output not informative:\n$actual_output\n\n" "$actual_output" "$expected_output"
+}
+
+test_should_not_be_able_to_execute_scripts_in_nested_paths() {
+	expected_output="unknown command 'nested-cmd'"
+	actual_output=$(./foopak nested-cmd 2>&1); exit_status=$?
+	assertNotEquals "program exited with success code." "0" "$exit_status"
+	assertContains "output not informative:\n$actual_output\n\n" "$actual_output" "$expected_output"
+}
+
+test_should_not_be_able_to_execute_scripts_not_in_command_list() {
+	expected_output="unknown command 'unlinked-file'"
+	actual_output=$(./foopak unlinked-file 2>&1); exit_status=$?
+	assertNotEquals "program exited with success code." "0" "$exit_status"
+	assertContains "output not informative:\n$actual_output\n\n" "$actual_output" "$expected_output"
+}
+
+test_should_add_module_as_git_module() {
+	assertContains \
+		"module not correctly added to .gitmodules:\n$output\n\n$gitmodules_content\n\n" \
+		"$gitmodules_content" \
+		"test_modules/subdir/rockerbacon/foopak-mock-module"
+}
+
+test_should_add_module_using_relative_path() {
+	assertNotContains \
+		".gitmodules contains module added with absolute path:\n$output\n\n$gitmodules_content\n\n" \
+		"$gitmodules_content" \
+		"$project_root"
+}
+
+. "$project_root/shunit2/shunit2"
+

--- a/tests/remove-modules/test_after-commit.sh
+++ b/tests/remove-modules/test_after-commit.sh
@@ -9,7 +9,7 @@ oneTimeSetUp() {
 
 	git submodule add \
 		https://github.com/rockerbacon/foopak-mock-module \
-		foopak_modules/rockerbacon_foopak-mock-module \
+		foopak_modules/rockerbacon/foopak-mock-module \
 	&> /dev/null
 
 	git commit -m "added mock module"
@@ -17,7 +17,7 @@ oneTimeSetUp() {
 	echo "unrelated_change" >> .gitignore
 	touch unrelated_file
 
-	output=$(./foopak remove rockerbacon_foopak-mock-module 2>&1); \
+	output=$(./foopak remove rockerbacon/foopak-mock-module 2>&1); \
 		exit_code=$?
 
 	working_tree_state=$(git status)
@@ -37,8 +37,8 @@ test_should_execute_successfuly() {
 
 test_should_remove_module_folder() {
 	assertFalse \
-		"did not remove 'foopak_modules/rockerbacon_foopak-mock-module'." \
-		"[ -d foopak_modules/rockerbacon_foopak-mock-module ]"
+		"did not remove 'foopak_modules/rockerbacon/foopak-mock-module'." \
+		"[ -d foopak_modules/rockerbacon/foopak-mock-module ]"
 }
 
 test_should_remove_module_from_gitmodules() {
@@ -46,13 +46,13 @@ test_should_remove_module_from_gitmodules() {
 	assertNotContains \
 		"module still listed in '.gitmodules'" \
 		"$gitmodules" \
-		"rockerbacon_foopak-mock-module"
+		"rockerbacon/foopak-mock-module"
 }
 
 test_should_remove_module_from_cache() {
 	assertFalse \
 		"module still cached in '.git/modules'" \
-		"[ -d .git/modules/rockerbacon_foopak-mock-module ]"
+		"[ -d .git/modules/rockerbacon/foopak-mock-module ]"
 }
 
 test_should_remove_module_from_config() {
@@ -60,7 +60,7 @@ test_should_remove_module_from_config() {
 	assertNotContains \
 		"module still listed in '.git/config'" \
 		"$gitconfig" \
-		"rockerbacon_foopak-mock-module"
+		"rockerbacon/foopak-mock-module"
 }
 
 test_should_add_module_removal_to_the_working_tree() {

--- a/tests/remove-modules/test_before-commit.sh
+++ b/tests/remove-modules/test_before-commit.sh
@@ -9,13 +9,13 @@ oneTimeSetUp() {
 
 	git submodule add \
 		https://github.com/rockerbacon/foopak-mock-module \
-		foopak_modules/rockerbacon_foopak-mock-module \
+		foopak_modules/rockerbacon/foopak-mock-module \
 	&> /dev/null
 
 	echo "unrelated_change" >> .gitignore
 	touch unrelated_file
 
-	output=$(./foopak remove rockerbacon_foopak-mock-module 2>&1); \
+	output=$(./foopak remove rockerbacon/foopak-mock-module 2>&1); \
 		exit_code=$?
 
 	working_tree_state=$(git status)
@@ -35,8 +35,8 @@ test_should_execute_successfuly() {
 
 test_should_remove_module_folder() {
 	assertFalse \
-		"did not remove 'foopak_modules/rockerbacon_foopak-mock-module'." \
-		"[ -d foopak_modules/rockerbacon_foopak-mock-module ]"
+		"did not remove 'foopak_modules/rockerbacon/foopak-mock-module'." \
+		"[ -d foopak_modules/rockerbacon/foopak-mock-module ]"
 }
 
 test_should_remove_module_from_gitmodules() {
@@ -44,13 +44,13 @@ test_should_remove_module_from_gitmodules() {
 	assertNotContains \
 		"module still listed in '.gitmodules'" \
 		"$gitmodules" \
-		"rockerbacon_foopak-mock-module"
+		"rockerbacon/foopak-mock-module"
 }
 
 test_should_remove_module_from_cache() {
 	assertFalse \
 		"module still cached in '.git/modules'" \
-		"[ -d .git/modules/rockerbacon_foopak-mock-module ]"
+		"[ -d .git/modules/rockerbacon/foopak-mock-module ]"
 }
 
 test_should_remove_module_from_config() {
@@ -58,7 +58,7 @@ test_should_remove_module_from_config() {
 	assertNotContains \
 		"module still listed in '.git/config'" \
 		"$gitconfig" \
-		"rockerbacon_foopak-mock-module"
+		"rockerbacon/foopak-mock-module"
 }
 
 test_should_remove_module_from_the_working_tree() {

--- a/tests/remove-modules/test_with-custom-directory.sh
+++ b/tests/remove-modules/test_with-custom-directory.sh
@@ -1,0 +1,91 @@
+#!/bin/bash
+
+project_root=$(realpath "$(dirname $0)/../..")
+
+oneTimeSetUp() {
+	environment_dir=$("$project_root/tests/setup_environment.sh")
+	cd $environment_dir
+	mkdir -p custom_dir
+
+	git submodule add \
+		https://github.com/rockerbacon/foopak-mock-module \
+		custom_dir/rockerbacon/foopak-mock-module \
+	&> /dev/null
+
+	echo "unrelated_change" >> .gitignore
+	touch unrelated_file
+
+	output=$(./foopak remove --dir custom_dir rockerbacon/foopak-mock-module 2>&1); \
+		exit_code=$?
+
+	working_tree_state=$(git status)
+}
+
+oneTimeTearDown() {
+	cd "$project_root"
+	rm -rf $environment_dir
+}
+
+test_should_execute_successfuly() {
+	assertEquals \
+		"exited with error:\n$output\n\n" \
+		0 \
+		$exit_code
+}
+
+test_should_remove_module_folder() {
+	assertFalse \
+		"did not remove 'custom_dir/rockerbacon/foopak-mock-module'." \
+		"[ -d custom_dir/rockerbacon/foopak-mock-module ]"
+}
+
+test_should_remove_module_from_gitmodules() {
+	gitmodules=$(cat .gitmodules)
+	assertNotContains \
+		"module still listed in '.gitmodules'" \
+		"$gitmodules" \
+		"rockerbacon/foopak-mock-module"
+}
+
+test_should_remove_module_from_cache() {
+	assertFalse \
+		"module still cached in '.git/modules'" \
+		"[ -d .git/modules/rockerbacon/foopak-mock-module ]"
+}
+
+test_should_remove_module_from_config() {
+	gitconfig=$(cat .git/config)
+	assertNotContains \
+		"module still listed in '.git/config'" \
+		"$gitconfig" \
+		"rockerbacon/foopak-mock-module"
+}
+
+test_should_remove_module_from_the_working_tree() {
+	assertNotContains \
+		"working tree has module related changes:\n$working_tree_state\n\n" \
+		"$working_tree_state" \
+		"custom_dir"
+
+	assertNotContains \
+		"working tree has module related changes:\n$working_tree_state\n\n" \
+		"$working_tree_state" \
+		".gitmodules"
+}
+
+test_should_not_remove_unrelated_changes_from_the_working_tree() {
+	assertContains \
+		"removed unrelated change to '.gitignore' from the working tree" \
+		"$working_tree_state" \
+		".gitignore"
+}
+
+test_should_not_remove_unrelated_untracked_files_from_the_working_tree() {
+	assertContains \
+		"removed unrelated untracked file 'unrelated_file' from the working tree" \
+		"$working_tree_state" \
+		"unrelated_file"
+}
+
+. "$project_root/shunit2/shunit2"
+


### PR DESCRIPTION
By default modules are added to directory `foopak_modules`. This PR adds a new option which allows modules to be added under a custom directory.

This option is intended to allow modules to use Foopak's core functionality without needing to implement their own. A module `node`, for example, could use Foopak's method to add modules under `node_modules`.