### PR TITLE
Improved test setup script

### DIFF
--- a/src/constants.sh
+++ b/src/constants.sh
@@ -1,3 +1,3 @@
-project_root=$(realpath $(dirname $0))
+project_root=$(realpath $(dirname "${BASH_SOURCE[0]}"))
 escaped_project_root=$(echo "$project_root" | sed 's/\//\\\//g')
 

--- a/tests/add-modules/test_with-alias.sh
+++ b/tests/add-modules/test_with-alias.sh
@@ -3,8 +3,7 @@
 project_root=$(realpath "$(dirname $0)/../..")
 
 oneTimeSetUp() {
-	environment_dir=$("$project_root/tests/setup_environment.sh")
-	cd $environment_dir
+	source "$project_root/tests/setup_environment.sh"
 	output=$(./foopak add --alias "mock-alias" rockerbacon/foopak-mock-module 2>&1); \
 		exit_code=$?
 
@@ -12,8 +11,7 @@ oneTimeSetUp() {
 }
 
 oneTimeTearDown() {
-	cd "$project_root"
-	rm -rf $environment_dir
+	teardown_environment
 }
 
 test_should_execute_without_errors() {

--- a/tests/add-modules/test_with-command-conflicts.sh
+++ b/tests/add-modules/test_with-command-conflicts.sh
@@ -3,8 +3,7 @@
 project_root=$(realpath "$(dirname $0)/../..")
 
 oneTimeSetUp() {
-	environment_dir=$("$project_root/tests/setup_environment.sh")
-	cd $environment_dir
+	source "$project_root/tests/setup_environment.sh"
 	./foopak add rockerbacon/foopak-mock-module 2>/dev/null 1>/dev/null
 	output=$(./foopak add --alias 'mock-alias' rockerbacon/foopak-mock-module 2>&1); \
 		exit_code=$?
@@ -14,8 +13,7 @@ oneTimeSetUp() {
 }
 
 oneTimeTearDown() {
-	cd "$project_root"
-	rm -rf $environment_dir
+	teardown_environment
 }
 
 test_should_exit_with_error_code() {

--- a/tests/add-modules/test_with-default-args.sh
+++ b/tests/add-modules/test_with-default-args.sh
@@ -3,8 +3,7 @@
 project_root=$(realpath "$(dirname $0)/../..")
 
 oneTimeSetUp() {
-	environment_dir=$("$project_root/tests/setup_environment.sh")
-	cd $environment_dir
+	source "$project_root/tests/setup_environment.sh"
 	output=$(./foopak add rockerbacon/foopak-mock-module 2>&1); \
 		exit_code=$?
 
@@ -12,8 +11,7 @@ oneTimeSetUp() {
 }
 
 oneTimeTearDown() {
-	cd "$project_root"
-	rm -rf $environment_dir
+	teardown_environment
 }
 
 test_should_execute_without_errors() {

--- a/tests/add-modules/test_with-module-folder-conflict.sh
+++ b/tests/add-modules/test_with-module-folder-conflict.sh
@@ -3,8 +3,7 @@
 project_root=$(realpath "$(dirname $0)/../..")
 
 oneTimeSetUp() {
-	environment_dir=$("$project_root/tests/setup_environment.sh")
-	cd $environment_dir
+	source "$project_root/tests/setup_environment.sh"
 	mkdir -p foopak_modules/rockerbacon/foopak-mock-module
 	output=$(./foopak add rockerbacon/foopak-mock-module 2>&1); exit_code=$?
 
@@ -12,8 +11,7 @@ oneTimeSetUp() {
 }
 
 oneTimeTearDown() {
-	cd "$project_root"
-	rm -rf $environment_dir
+	teardown_environment
 }
 
 test_should_exit_with_error_code() {

--- a/tests/add-modules/test_with-specific-branch.sh
+++ b/tests/add-modules/test_with-specific-branch.sh
@@ -3,8 +3,7 @@
 project_root=$(realpath "$(dirname $0)/../..")
 
 oneTimeSetUp() {
-	environment_dir=$("$project_root/tests/setup_environment.sh")
-	cd $environment_dir
+	source "$project_root/tests/setup_environment.sh"
 	output=$(./foopak add --branch v3 rockerbacon/foopak-mock-module 2>&1); \
 		exit_code=$?
 
@@ -12,8 +11,7 @@ oneTimeSetUp() {
 }
 
 oneTimeTearDown() {
-	cd "$project_root"
-	rm -rf $environment_dir
+	teardown_environment
 }
 
 test_should_execute_without_errors() {

--- a/tests/add-modules/test_with-specific-directory.sh
+++ b/tests/add-modules/test_with-specific-directory.sh
@@ -3,8 +3,7 @@
 project_root=$(realpath "$(dirname $0)/../..")
 
 oneTimeSetUp() {
-	environment_dir=$("$project_root/tests/setup_environment.sh")
-	cd $environment_dir
+	source "$project_root/tests/setup_environment.sh"
 	output=$(./foopak add --dir "test_modules/subdir" rockerbacon/foopak-mock-module 2>&1); \
 		exit_code=$?
 
@@ -12,8 +11,7 @@ oneTimeSetUp() {
 }
 
 oneTimeTearDown() {
-	cd "$project_root"
-	rm -rf $environment_dir
+	teardown_environment
 }
 
 test_should_execute_without_errors() {

--- a/tests/add-modules/test_with-specific-tag.sh
+++ b/tests/add-modules/test_with-specific-tag.sh
@@ -3,8 +3,7 @@
 project_root=$(realpath "$(dirname $0)/../..")
 
 oneTimeSetUp() {
-	environment_dir=$("$project_root/tests/setup_environment.sh")
-	cd $environment_dir
+	source "$project_root/tests/setup_environment.sh"
 	output=$(./foopak add --tag v3.1.0 rockerbacon/foopak-mock-module 2>&1); \
 		exit_code=$?
 
@@ -12,8 +11,7 @@ oneTimeSetUp() {
 }
 
 oneTimeTearDown() {
-	cd "$project_root"
-	rm -rf $environment_dir
+	teardown_environment
 }
 
 test_should_execute_without_errors() {

--- a/tests/remove-modules/test_after-commit.sh
+++ b/tests/remove-modules/test_after-commit.sh
@@ -3,8 +3,7 @@
 project_root=$(realpath "$(dirname $0)/../..")
 
 oneTimeSetUp() {
-	environment_dir=$("$project_root/tests/setup_environment.sh")
-	cd $environment_dir
+	source "$project_root/tests/setup_environment.sh"
 	mkdir -p foopak_modules
 
 	submodule_add_output=$(git submodule add \
@@ -24,8 +23,7 @@ oneTimeSetUp() {
 }
 
 oneTimeTearDown() {
-	cd "$project_root"
-	rm -rf $environment_dir
+	teardown_environment
 }
 
 test_should_execute_successfuly() {

--- a/tests/remove-modules/test_before-commit.sh
+++ b/tests/remove-modules/test_before-commit.sh
@@ -3,8 +3,7 @@
 project_root=$(realpath "$(dirname $0)/../..")
 
 oneTimeSetUp() {
-	environment_dir=$("$project_root/tests/setup_environment.sh")
-	cd $environment_dir
+	source "$project_root/tests/setup_environment.sh"
 	mkdir -p foopak_modules
 
 	submodule_add_output=$(git submodule add \
@@ -22,8 +21,7 @@ oneTimeSetUp() {
 }
 
 oneTimeTearDown() {
-	cd "$project_root"
-	rm -rf $environment_dir
+	teardown_environment
 }
 
 test_should_execute_successfuly() {

--- a/tests/remove-modules/test_with-custom-directory.sh
+++ b/tests/remove-modules/test_with-custom-directory.sh
@@ -3,8 +3,7 @@
 project_root=$(realpath "$(dirname $0)/../..")
 
 oneTimeSetUp() {
-	environment_dir=$("$project_root/tests/setup_environment.sh")
-	cd $environment_dir
+	source "$project_root/tests/setup_environment.sh"
 	mkdir -p custom_dir
 
 	submodule_add_output=$(git submodule add \
@@ -22,8 +21,7 @@ oneTimeSetUp() {
 }
 
 oneTimeTearDown() {
-	cd "$project_root"
-	rm -rf $environment_dir
+	teardown_environment
 }
 
 test_should_execute_successfuly() {

--- a/tests/setup_environment.sh
+++ b/tests/setup_environment.sh
@@ -1,22 +1,27 @@
 #!/bin/bash
 
-script_dir=$(realpath $(dirname $0))
-project_root=$(realpath "$script_dir/..")
+script_dir=$(realpath $(dirname "${BASH_SOURCE[0]}"))
+dev_environment=$(realpath "$script_dir/..")
 
-project_root_owner=$(stat --format=%U "$project_root")
+dev_environment_owner=$(stat --format=%U "$dev_environment")
 
-if [ "$project_root_owner" != "$USER" ]; then
-	echo "ERROR: user '$USER' does not own the project root located in '$project_root'" >&2
+if [ "$dev_environment_owner" != "$USER" ]; then
+	echo "ERROR: user '$USER' does not own the project root located in '$dev_environment'" >&2
 	return 1
 fi
 
 mkdir -p /tmp/foopak_test_environments
-environment_dir=$(mktemp -d /tmp/foopak_test_environments/XXXXXX)
+test_environment=$(mktemp -d /tmp/foopak_test_environments/XXXXXX)
 
-cp -R "$project_root"/* "$project_root"/.[!.]* $environment_dir/
+cp -R "$dev_environment"/* "$dev_environment"/.[!.]* $test_environment/
 
-"$environment_dir"/build.sh
-mv "$environment_dir/build/foopak" "$environment_dir/foopak"
+"$test_environment"/build.sh
+mv "$test_environment/build/foopak" "$test_environment/foopak"
 
-echo "$environment_dir"
+teardown_environment() {
+	cd "$dev_environment"
+	rm -rf "$test_environment"
+}
+
+cd "$test_environment"
 

--- a/tests/setup_environment.sh
+++ b/tests/setup_environment.sh
@@ -13,15 +13,22 @@ fi
 mkdir -p /tmp/foopak_test_environments
 test_environment=$(mktemp -d /tmp/foopak_test_environments/XXXXXX)
 
-cp -R "$dev_environment"/* "$dev_environment"/.[!.]* $test_environment/
+reset_environment() {
+	rm -rf "$test_environment"/* "$test_environment"/.[!.]*
 
-"$test_environment"/build.sh
-mv "$test_environment/build/foopak" "$test_environment/foopak"
+	ls "$test_environment/"
+
+	cp -R "$dev_environment"/* "$dev_environment"/.[!.]* $test_environment/
+
+	"$test_environment"/build.sh
+	mv -f "$test_environment/build/foopak" "$test_environment/foopak"
+}
 
 teardown_environment() {
 	cd "$dev_environment"
 	rm -rf "$test_environment"
 }
 
+reset_environment
 cd "$test_environment"
 


### PR DESCRIPTION
## Description

Improves the test setup script to make it easier to use for debugging. Previously, multiple steps were necessary to execute manual tests and now only two commands should be necessary.

## Setup

The following command can be used to setup a test environment and immediately change the working directory to said environment:

```bash
$ . tests/setup_environment.sh
```
Note the dot before the script. The script must be executed as source.

## Reseting

In case any changes are made in the development environment, the test environment can be easily updated with:

```bash
$ reset_environment
```

## Teardown

Once done with all tests, a single command is used to purge the environment and return the developer to the project:

```bash
$ teardown_environment
```
