### PR TITLE
Fix adding module without command list

### DIFF
--- a/src/add.sh
+++ b/src/add.sh
@@ -119,23 +119,27 @@ add() {
 		fi
 	fi
 
-	exec 3< "$module_install_path/foopak_meta/command_list.conf"
-		command_list_version=$(read -u 3)
+	command_list="$module_install_path/foopak_meta/command_list.conf"
 
-		while read -u 3 command || [ -n "$command" ]; do
-			[ -z "$command" ] && continue
-			[ "${command:0:1}" == "#" ] && continue
+	if [ -f "$command_list" ]; then
+		exec 3< "$command_list"
+			command_list_version=$(read -u 3)
 
-			command=$(echo "$command" | sed "s/\s.*$//")
+			while read -u 3 command || [ -n "$command" ]; do
+				[ -z "$command" ] && continue
+				[ "${command:0:1}" == "#" ] && continue
 
-			conflicting_module=$(locate_cmd --print-module --exclude-dir "$module_install_path" "$command")
+				command=$(echo "$command" | sed "s/\s.*$//")
 
-			if [ -n "$conflicting_module" ]; then
-				echo "ERROR: could not add module: command '$command' conflicts with module '$conflicting_module'" >&2
-				remove "$module_alias"
-				exit 1
-			fi
-		done
-	exec 3>&-
+				conflicting_module=$(locate_cmd --print-module --exclude-dir "$module_install_path" "$command")
+
+				if [ -n "$conflicting_module" ]; then
+					echo "ERROR: could not add module: command '$command' conflicts with module '$conflicting_module'" >&2
+					remove "$module_alias"
+					exit 1
+				fi
+			done
+		exec 3>&-
+	fi
 }
 

--- a/tests/add-modules/test_without-command-list.sh
+++ b/tests/add-modules/test_without-command-list.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+project_root=$(realpath "$(dirname $0)/../..")
+
+oneTimeSetUp() {
+	source "$project_root/tests/setup_environment.sh"
+	output=$(./foopak add --commit 30fc847057f4348cb6227c181de3671c19ee2457 rockerbacon/foopak-mock-module 2>&1); \
+		exit_code=$?
+
+	gitmodules_content=$(cat .gitmodules)
+}
+
+oneTimeTearDown() {
+	teardown_environment
+}
+
+test_should_execute_without_errors() {
+	assertEquals "program exited with error:\n$output\n\n" "0" "$exit_code"
+}
+
+test_should_add_module_in_correct_path() {
+	assertTrue \
+		"path 'foopak_modules/rockerbacon/foopak-mock-module' not found" \
+		'[ -d "foopak_modules/rockerbacon/foopak-mock-module" ]'
+}
+
+test_should_add_module_as_git_module() {
+	assertContains \
+		"module not correctly added to .gitmodules:\n$output\n\n$gitmodules_content\n\n" \
+		"$gitmodules_content" \
+		"foopak_modules/rockerbacon/foopak-mock-module"
+}
+
+test_should_add_module_using_relative_path() {
+	assertNotContains \
+		".gitmodules contains module added with absolute path:\n$output\n\n$gitmodules_content\n\n" \
+		"$gitmodules_content" \
+		"$project_root"
+}
+
+. "$project_root/shunit2/shunit2"
+


### PR DESCRIPTION
## Problem

When adding a module without a command list the program would be caught in an infinite loop trying to read an non existent file.

## Solution

Check if the command list file exists before attempting to read it.