### PR TITLE
Add support for SSH and HTTP

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,7 +15,10 @@ jobs:
         with:
           submodules: recursive
           fetch-depth: 0
-          ssh-key: ${{ secrets.CI_SSH_KEY }}
+
+      - uses: webfactory/ssh-agent@v0.4.0
+        with:
+          ssh-private-key: ${{ secrets.CI_SSH_KEY }}
 
       - name: set git email
         run: git config user.email ${{ secrets.CI_EMAIL }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,12 +15,13 @@ jobs:
         with:
           submodules: recursive
           fetch-depth: 0
+          ssh-key: ${{ secrets.CI_SSH_KEY }}
 
       - name: set git email
-        run: git config user.email ci@foopak.org
+        run: git config user.email ${{ secrets.CI_EMAIL }}
 
       - name: set git user
-        run: git config user.name foopak_ci
+        run: git config user.name ${{ secrets.CI_USER }}
 
       - name: run all tests
         run: ./ci/tests.sh

--- a/src/add.sh
+++ b/src/add.sh
@@ -32,12 +32,17 @@ OPTIONS:
 
 	--help,-h	print this help message and exit
 
+	--http,--https	use HTTP or HTTPS when adding the module
+			by default, modules are added using SSH
+
 EOF
 }
 
 add() {
 	###   DEFAULTS    ###
-	git_server="https://github.com"
+	protocol_prefix="git@"
+	protocol_domain_terminator=":"
+	git_server_domain="github.com"
 	module_home_relative_dir="foopak_modules"
 	module_options=()
 	###   DEFAULTS   ###
@@ -66,6 +71,12 @@ add() {
 			--help|-h)
 				print_add_help
 				exit 0
+			;;
+
+			--http|--https)
+				shift 1
+				protocol_prefix="${option#--}://"
+				protocol_domain_terminator="/"
 			;;
 
 			--*|-*)
@@ -108,8 +119,9 @@ add() {
 		exit 1
 	fi
 
+	repository_address="${protocol_prefix}${git_server_domain}${protocol_domain_terminator}${module_path}"
 	cd "$project_root" || exit 1
-	git submodule add "${module_options[@]}" "$git_server/$module_path" "$module_install_path"
+	git submodule add "${module_options[@]}" "$repository_address" "$module_install_path"
 
 	if [ -n "$module_version" ]; then
 		restore_workdir=$PWD

--- a/src/add.sh
+++ b/src/add.sh
@@ -18,8 +18,11 @@ OPTIONS:
 			default is MODULE with slashes
 			replaced by underscores
 
-	--tag,-t,	use specific tag or commit
-	--commit,-c	default is the latest commit in the default remote
+	--branch,-b	use specific branch
+			default is the default remote branch
+
+	--commit,-c,	use specific tag or commit
+	--tag,-t	default is the latest commit in the default remote
 
 	--dir,-d	add module under different directory
 			default is foopak_modules
@@ -27,21 +30,21 @@ OPTIONS:
 				modules outside 'foopak_modules'
 				will not be scanned for commands
 
-	--branch,-b	use specific branch
-			default is the default remote branch
-
 	--help,-h	print this help message and exit
 
-	--http,--https	use HTTP or HTTPS when adding the module
-			by default, modules are added using SSH
+	--http		use HTTP when adding the module
+			by default, modules are added using HTTPS
+
+	--ssh		use SSH when adding the module
+			by default, modules are added using HTTPS
 
 EOF
 }
 
 add() {
 	###   DEFAULTS    ###
-	protocol_prefix="git@"
-	protocol_domain_terminator=":"
+	protocol_prefix="https://"
+	protocol_domain_terminator="/"
 	git_server_domain="github.com"
 	module_home_relative_dir="foopak_modules"
 	module_options=()
@@ -73,10 +76,16 @@ add() {
 				exit 0
 			;;
 
-			--http|--https)
+			--http)
 				shift 1
-				protocol_prefix="${option#--}://"
+				protocol_prefix="http://"
 				protocol_domain_terminator="/"
+			;;
+
+			--ssh)
+				shift 1
+				protocol_prefix="git@"
+				protocol_domain_terminator=":"
 			;;
 
 			--*|-*)

--- a/tests/add-modules/test_with-default-args.sh
+++ b/tests/add-modules/test_with-default-args.sh
@@ -58,11 +58,11 @@ test_should_add_module_using_relative_path() {
 		"$project_root"
 }
 
-test_should_add_module_using_ssh() {
+test_should_add_module_using_https() {
 	assertContains \
 		".gitmodules contains module added with wrong protocol:\n$output\n\n$gitmodules_content\n\n" \
 		"$gitmodules_content" \
-		"git@github.com:rockerbacon/foopak-mock-module"
+		"https://github.com/rockerbacon/foopak-mock-module"
 }
 
 # shellcheck disable=SC1090

--- a/tests/add-modules/test_with-http-protocol.sh
+++ b/tests/add-modules/test_with-http-protocol.sh
@@ -5,7 +5,7 @@ project_root=$(realpath "$(dirname "${BASH_SOURCE[0]}")/../..")
 oneTimeSetUp() {
 	# shellcheck source=./tests/setup_environment.sh
 	source "$project_root/tests/setup_environment.sh"
-	output=$(./foopak add rockerbacon/foopak-mock-module 2>&1); \
+	output=$(./foopak add --http rockerbacon/foopak-mock-module 2>&1); \
 		exit_code=$?
 
 	gitmodules_content=$(cat .gitmodules)
@@ -58,11 +58,11 @@ test_should_add_module_using_relative_path() {
 		"$project_root"
 }
 
-test_should_add_module_using_ssh() {
+test_should_add_module_using_http() {
 	assertContains \
 		".gitmodules contains module added with wrong protocol:\n$output\n\n$gitmodules_content\n\n" \
 		"$gitmodules_content" \
-		"git@github.com:rockerbacon/foopak-mock-module"
+		"http://github.com/rockerbacon/foopak-mock-module"
 }
 
 # shellcheck disable=SC1090

--- a/tests/add-modules/test_with-https-protocol.sh
+++ b/tests/add-modules/test_with-https-protocol.sh
@@ -5,7 +5,7 @@ project_root=$(realpath "$(dirname "${BASH_SOURCE[0]}")/../..")
 oneTimeSetUp() {
 	# shellcheck source=./tests/setup_environment.sh
 	source "$project_root/tests/setup_environment.sh"
-	output=$(./foopak add rockerbacon/foopak-mock-module 2>&1); \
+	output=$(./foopak add --https rockerbacon/foopak-mock-module 2>&1); \
 		exit_code=$?
 
 	gitmodules_content=$(cat .gitmodules)
@@ -58,11 +58,11 @@ test_should_add_module_using_relative_path() {
 		"$project_root"
 }
 
-test_should_add_module_using_ssh() {
+test_should_add_module_using_https() {
 	assertContains \
 		".gitmodules contains module added with wrong protocol:\n$output\n\n$gitmodules_content\n\n" \
 		"$gitmodules_content" \
-		"git@github.com:rockerbacon/foopak-mock-module"
+		"https://github.com/rockerbacon/foopak-mock-module"
 }
 
 # shellcheck disable=SC1090

--- a/tests/add-modules/test_with-ssh-protocol.sh
+++ b/tests/add-modules/test_with-ssh-protocol.sh
@@ -5,7 +5,7 @@ project_root=$(realpath "$(dirname "${BASH_SOURCE[0]}")/../..")
 oneTimeSetUp() {
 	# shellcheck source=./tests/setup_environment.sh
 	source "$project_root/tests/setup_environment.sh"
-	output=$(./foopak add --https rockerbacon/foopak-mock-module 2>&1); \
+	output=$(./foopak add --ssh rockerbacon/foopak-mock-module 2>&1); \
 		exit_code=$?
 
 	gitmodules_content=$(cat .gitmodules)
@@ -58,11 +58,11 @@ test_should_add_module_using_relative_path() {
 		"$project_root"
 }
 
-test_should_add_module_using_https() {
+test_should_add_module_using_ssh() {
 	assertContains \
 		".gitmodules contains module added with wrong protocol:\n$output\n\n$gitmodules_content\n\n" \
 		"$gitmodules_content" \
-		"https://github.com/rockerbacon/foopak-mock-module"
+		"git@github.com:rockerbacon/foopak-mock-module"
 }
 
 # shellcheck disable=SC1090


### PR DESCRIPTION
Adds options to add modules using SSH or HTTP, with HTTPS being used by default.

SSH is handy for cloning private repositories without inputting credentials.

HTTP is useful for adding modules from self-managed servers which might not use any form of encryption.